### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LupaDevStudio/Postrias/security/code-scanning/1](https://github.com/LupaDevStudio/Postrias/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/pylint.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is:

- `contents: read`

Place it after the `on:` section (or before `jobs:`) to keep structure clear. No functional behavior changes are introduced; this only restricts token scope to least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
